### PR TITLE
Move the Jit config to ~/.jit/config.yaml

### DIFF
--- a/.jit/.gitignore
+++ b/.jit/.gitignore
@@ -1,1 +1,0 @@
-config.yaml

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-// Config describes the format of the YAML config stored in .jit/config.yaml.
+// Config describes the format of the YAML config stored in ~/.jit/config.yaml.
 type Config struct {
 	Jira struct {
 		Host  string

--- a/config/load.go
+++ b/config/load.go
@@ -2,40 +2,47 @@ package config
 
 import (
 	"fmt"
+	"github.com/fatih/color"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"path"
 )
 
-// Load reads the Jit configuration from a Git repository.
-func Load(gitRepoPath string) (*Config, error) {
-	configDirPath := path.Join(gitRepoPath, ".jit")
-	_, err := os.Stat(configDirPath)
+// Load reads the Jit configuration from a home directory.
+func Load(homePath string, gitRepoPath string) (*Config, error) {
+	homeConfigDirPath := path.Join(homePath, ".jit")
+	configFilePath := path.Join(homeConfigDirPath, "config.yaml")
+
+	// We used to store the Jit config directly within the Git repo. If we find it
+	// there, we'll automatically move it to the home directory.
+	oldGitConfigFilePath := path.Join(gitRepoPath, ".jit", "config.yaml")
+
+	_, err := os.Stat(homeConfigDirPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// Create .jit directory with only read/write/exec access for current user.
-			os.Mkdir(configDirPath, 0700)
+			os.Mkdir(homeConfigDirPath, 0700)
 		} else {
 			return nil, err
 		}
 	}
-	gitIgnorePath := path.Join(configDirPath, ".gitignore")
-	_, err = os.Stat(gitIgnorePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			ioutil.WriteFile(gitIgnorePath, []byte("config.yaml\n"), 0600)
-		} else {
-			return nil, err
-		}
-	}
-	configFilePath := path.Join(configDirPath, "config.yaml")
 	_, err = os.Stat(configFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			_, err = Prompt(configFilePath, nil)
-			if err != nil {
-				return nil, err
+			// Check if there's an old config file inside the Git repo.
+			_, oldGitConfigErr := os.Stat(oldGitConfigFilePath)
+			if oldGitConfigErr == nil {
+				// There is one. Let's move it to the home directory.
+				os.Rename(oldGitConfigFilePath, configFilePath)
+				fmt.Println("We've moved .jit/config.yaml to your home directory.")
+				fmt.Println(color.MagentaString("You can now safely delete the .jit directory in this Git repository."))
+			} else {
+				// There is no existing config file. Create a new one.
+				_, err = Prompt(configFilePath, nil)
+				if err != nil {
+					return nil, err
+				}
 			}
 		} else {
 			return nil, err

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/zenclabs/jit/versioning"
 	"gopkg.in/AlecAivazis/survey.v1"
 	"log"
+	"os/user"
 )
 
 func main() {
@@ -18,7 +19,13 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	c, err := config.Load(*gitRepoPath)
+
+	usr, err := user.Current()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	c, err := config.Load(usr.HomeDir, *gitRepoPath)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
The existing Jit config in the current Git repository is automatically moved to ~/.jit if there is not one already.

This fixes #7.